### PR TITLE
refactor: API 구조 개선 및 네이밍 컨벤션 통일

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -9,57 +9,55 @@ export const apiClient = axios.create({
 
 const apiRoutes = {
   // Background Images
-  getBackgroundImages: '/background-images/',
+  backgroundImages: '/background-images',
+
   // Profile Images
-  getProfileImages: '/profile-images/',
+  profileImages: '/profile-images',
+
   // Messages
-  getMessages: (team, messageId) => `/${team}/messages/${messageId}/`,
-  putMessage: (team, messageId) => `/${team}/messages/${messageId}/`,
-  patchMessage: (team, messageId) => `/${team}/messages/${messageId}/`,
-  deleteMessage: (team, messageId) => `/${team}/messages/${messageId}/`,
+  messages: (team, messageId) => `/${team}/messages/${messageId}`,
+
   // Recipients
-  getRecipients: (team) => `/${team}/recipients/`,
-  postRecipient: (team) => `/${team}/recipients/`,
-  getRecipient: (team, recipientId) => `/${team}/recipients/${recipientId}`,
-  deleteRecipient: (team, recipientId) => `/${team}/recipients/${recipientId}`,
-  getRecipientMessages: (team, recipientId) => `/${team}/recipients/${recipientId}/messages/`,
-  postRecipientMessage: (team, recipientId) => `/${team}/recipients/${recipientId}/messages/`,
-  getRecipientReactions: (team, recipientId) => `/${team}/recipients/${recipientId}/reactions/`,
-  postRecipientReaction: (team, recipientId) => `/${team}/recipients/${recipientId}/reactions/`,
+  recipients: {
+    base: (team, recipientId) =>
+      recipientId ? `/${team}/recipients/${recipientId}` : `/${team}/recipients`,
+    messages: (team, recipientId) => `/${team}/recipients/${recipientId}/messages`,
+    reactions: (team, recipientId) => `/${team}/recipients/${recipientId}/reactions`,
+  },
 };
 
 const api = {
   // Background Images
-  getBackgroundImages: () => apiClient.get(apiRoutes.getBackgroundImages),
+  getBackgroundImages: () => apiClient.get(apiRoutes.backgroundImages),
 
   // Profile Images
-  getProfileImages: () => apiClient.get(apiRoutes.getProfileImages),
+  getProfileImages: () => apiClient.get(apiRoutes.profileImages),
 
   // Messages
-  getMessages: (team, messageId) => apiClient.get(apiRoutes.getMessages(team, messageId)),
-  putMessage: (team, messageId, data) => apiClient.put(apiRoutes.putMessage(team, messageId), data),
-  patchMessage: (team, messageId, data) =>
-    apiClient.patch(apiRoutes.patchMessage(team, messageId), data),
-  deleteMessage: (team, messageId) => apiClient.delete(apiRoutes.deleteMessage(team, messageId)),
+  getMessages: (team, messageId) => apiClient.get(apiRoutes.messages(team, messageId)),
+  putMessages: (team, messageId, data) => apiClient.put(apiRoutes.messages(team, messageId), data),
+  patchMessages: (team, messageId, data) =>
+    apiClient.patch(apiRoutes.messages(team, messageId), data),
+  deleteMessages: (team, messageId) => apiClient.delete(apiRoutes.messages(team, messageId)),
 
   // Recipients
-  getRecipients: (team) => apiClient.get(apiRoutes.getRecipients(team)),
-  postRecipient: (team, data) => apiClient.post(apiRoutes.postRecipient(team), data),
-  getRecipient: (team, recipientId) => apiClient.get(apiRoutes.getRecipient(team, recipientId)),
-  deleteRecipient: (team, recipientId) =>
-    apiClient.delete(apiRoutes.deleteRecipient(team, recipientId)),
+  getRecipients: (team) => apiClient.get(apiRoutes.recipients.base(team)),
+  postRecipients: (team, data) => apiClient.post(apiRoutes.recipients.base(team), data),
+  getRecipients: (team, recipientId) => apiClient.get(apiRoutes.recipients.base(team, recipientId)),
+  deleteRecipients: (team, recipientId) =>
+    apiClient.delete(apiRoutes.recipients.base(team, recipientId)),
 
   // Recipient Messages
-  getRecipientMessages: (team, recipientId) =>
-    apiClient.get(apiRoutes.getRecipientMessages(team, recipientId)),
-  postRecipientMessage: (team, recipientId, data) =>
-    apiClient.post(apiRoutes.postRecipientMessage(team, recipientId), data),
+  getRecipientsMessages: (team, recipientId) =>
+    apiClient.get(apiRoutes.recipients.messages(team, recipientId)),
+  postRecipientsMessages: (team, recipientId, data) =>
+    apiClient.post(apiRoutes.recipients.messages(team, recipientId), data),
 
   // Recipient Reactions
-  getRecipientReactions: (team, recipientId) =>
-    apiClient.get(apiRoutes.getRecipientReactions(team, recipientId)),
-  postRecipientReaction: (team, recipientId, data) =>
-    apiClient.post(apiRoutes.postRecipientReaction(team, recipientId), data),
+  getRecipientsReactions: (team, recipientId) =>
+    apiClient.get(apiRoutes.recipients.reactions(team, recipientId)),
+  postRecipientsReactions: (team, recipientId, data) =>
+    apiClient.post(apiRoutes.recipients.reactions(team, recipientId), data),
 };
 
 export default api;

--- a/src/pages/RollingPaperList.jsx
+++ b/src/pages/RollingPaperList.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import api from '../api/axios';
+
+const RollingPaperList = () => {
+  const [popularRollingPapers, setPopularRollingPapers] = useState([]);
+  const [recentRollingPapers, setRecentRollingPapers] = useState([]);
+
+  useEffect(() => {
+    const fetchRollingPaperList = async () => {
+      try {
+        const response = await api.getRecipients('13-2');
+        const papers = response.data.results;
+
+        // 좋아요 수 기준으로 정렬하여 인기 롤링 페이퍼 설정
+        const sortedByReactionCount = [...papers].sort((a, b) => b.reactionCount - a.reactionCount);
+        setPopularRollingPapers(sortedByReactionCount);
+
+        // 생성일 기준으로 정렬하여 최근 롤링 페이퍼 설정
+        const sortedByDate = [...papers].sort(
+          (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+        );
+        setRecentRollingPapers(sortedByDate);
+      } catch (error) {
+        console.error('Error fetching rolling paper list:', error);
+      }
+    };
+    fetchRollingPaperList();
+  }, []);
+
+  return (
+    <div className="mt-[50px] flex flex-col gap-[50px]">
+      <div>
+        <div className="flex flex-col gap-[16px">
+          <span>인기 롤링 페이퍼 🔥</span>
+        </div>
+        <div>
+          {popularRollingPapers.map((paper) => (
+            <div key={paper.id}>{paper.name}</div>
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="flex flex-col gap-[16px]">
+          <span>최근에 만든 롤링 페이퍼 ⭐️️</span>
+        </div>
+        <div>
+          {recentRollingPapers.map((paper) => (
+            <div key={paper.id}>{paper.name}</div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RollingPaperList;


### PR DESCRIPTION
- apiRoutes 구조 개선
  - 동일한 엔드포인트를 가진 라우트들 통합
  - URL 생성 로직 단순화
  - 불필요한 URL 끝 슬래시(/) 제거

- API 메서드 네이밍 REST 컨벤션 적용
  - 모든 리소스 관련 메서드명 복수형으로 통일
  - message → messages
  - recipient → recipients
  - putMessage → putMessages
  - getRecipientMessages → getRecipientsMessages