### PR TITLE
Feature/rolling paper list

### DIFF
--- a/src/components/CarouselButton.jsx
+++ b/src/components/CarouselButton.jsx
@@ -1,0 +1,12 @@
+const CarouselButton = ({ direction, onClick, className }) => {
+  return (
+    <button
+      className={`cursor-pointer absolute ${direction === 'prev' ? 'left-0' : 'right-0'} top-[50px] z-10 ${className}`}
+      onClick={onClick}
+    >
+      {direction === 'prev' ? '<' : '>'}
+    </button>
+  );
+};
+
+export default CarouselButton;

--- a/src/components/RollingPaperCard.jsx
+++ b/src/components/RollingPaperCard.jsx
@@ -1,0 +1,9 @@
+const RollingPaperCard = ({ paper }) => {
+  return (
+    <div className="min-w-[275px] h-[260px]" key={paper.id}>
+      {paper.name}
+    </div>
+  );
+};
+
+export default RollingPaperCard;

--- a/src/components/RollingPaperCard.jsx
+++ b/src/components/RollingPaperCard.jsx
@@ -1,6 +1,6 @@
 const RollingPaperCard = ({ paper }) => {
   return (
-    <div className="min-w-[275px] h-[260px]" key={paper.id}>
+    <div className="w-[275px] h-[260px] max-md:w-[206px] max-md:h-[232px]" key={paper.id}>
       {paper.name}
     </div>
   );

--- a/src/components/RollingPaperCarousel.jsx
+++ b/src/components/RollingPaperCarousel.jsx
@@ -1,0 +1,30 @@
+import CarouselButton from './CarouselButton';
+import RollingPaperCard from './RollingPaperCard';
+
+const RollingPaperCarousel = ({ title, papers, currentIndex, onNext, onPrev, itemsPerView }) => {
+  return (
+    <div>
+      <div className="flex flex-col gap-[16px]">
+        <span>{title}</span>
+      </div>
+      <div className="flex gap-[20px] max-w-[1160px] overflow-hidden relative md:overflow-x-auto md:[&::-webkit-scrollbar]:hidden md:[&::-webkit-scrollbar-track]:hidden md:[&::-webkit-scrollbar-thumb]:hidden md:[-ms-overflow-style:none] md:[scrollbar-width:none]">
+        {currentIndex > 0 && <CarouselButton direction="prev" onClick={onPrev} />}
+        <div
+          className="flex gap-[20px] transition-transform duration-300 md:transform-none"
+          style={{
+            transform: `translateX(-${currentIndex * 295}px)`,
+          }}
+        >
+          {papers.map((paper) => (
+            <RollingPaperCard key={paper.id} paper={paper} />
+          ))}
+        </div>
+        {currentIndex < papers.length - itemsPerView && (
+          <CarouselButton direction="next" onClick={onNext} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RollingPaperCarousel;

--- a/src/components/RollingPaperCarousel.jsx
+++ b/src/components/RollingPaperCarousel.jsx
@@ -7,10 +7,12 @@ const RollingPaperCarousel = ({ title, papers, currentIndex, onNext, onPrev, ite
       <div className="flex flex-col gap-[16px]">
         <span>{title}</span>
       </div>
-      <div className="flex gap-[20px] max-w-[1160px] overflow-hidden relative md:overflow-x-auto md:[&::-webkit-scrollbar]:hidden md:[&::-webkit-scrollbar-track]:hidden md:[&::-webkit-scrollbar-thumb]:hidden md:[-ms-overflow-style:none] md:[scrollbar-width:none]">
-        {currentIndex > 0 && <CarouselButton direction="prev" onClick={onPrev} />}
+      <div className="flex gap-[20px] max-w-[1160px] overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] relative">
+        {currentIndex > 0 && (
+          <CarouselButton className="hidden xl:block" direction="prev" onClick={onPrev} />
+        )}
         <div
-          className="flex gap-[20px] transition-transform duration-300 md:transform-none"
+          className="flex gap-[20px] xl:transition-transform xl:duration-300 max-md:gap-[12px]"
           style={{
             transform: `translateX(-${currentIndex * 295}px)`,
           }}
@@ -20,7 +22,7 @@ const RollingPaperCarousel = ({ title, papers, currentIndex, onNext, onPrev, ite
           ))}
         </div>
         {currentIndex < papers.length - itemsPerView && (
-          <CarouselButton direction="next" onClick={onNext} />
+          <CarouselButton className="hidden xl:block" direction="next" onClick={onNext} />
         )}
       </div>
     </div>

--- a/src/components/RollingPaperCarousel.jsx
+++ b/src/components/RollingPaperCarousel.jsx
@@ -2,26 +2,31 @@ import CarouselButton from './CarouselButton';
 import RollingPaperCard from './RollingPaperCard';
 
 const RollingPaperCarousel = ({ title, papers, currentIndex, onNext, onPrev, itemsPerView }) => {
+  const isPrevButtonVisible = currentIndex > 0;
+  const isNextButtonVisible = currentIndex < papers.length - itemsPerView;
+
+  const getTransformStyle = (index) => ({
+    transform: `translateX(-${index * 295}px)`,
+  });
+
   return (
-    <div>
+    <div className="rolling-paper-carousel">
       <div className="flex flex-col gap-[16px]">
-        <span>{title}</span>
+        <span className="carousel-title">{title}</span>
       </div>
       <div className="flex gap-[20px] max-w-[1160px] overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] relative">
-        {currentIndex > 0 && (
+        {isPrevButtonVisible && (
           <CarouselButton className="hidden xl:block" direction="prev" onClick={onPrev} />
         )}
         <div
           className="flex gap-[20px] xl:transition-transform xl:duration-300 max-md:gap-[12px]"
-          style={{
-            transform: `translateX(-${currentIndex * 295}px)`,
-          }}
+          style={getTransformStyle(currentIndex)}
         >
           {papers.map((paper) => (
             <RollingPaperCard key={paper.id} paper={paper} />
           ))}
         </div>
-        {currentIndex < papers.length - itemsPerView && (
+        {isNextButtonVisible && (
           <CarouselButton className="hidden xl:block" direction="next" onClick={onNext} />
         )}
       </div>

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -6,7 +6,7 @@ const Layout = () => {
   return (
     <div>
       <header>헤더입니당</header>
-      <main className="flex justify-center">
+      <main className="flex xl:justify-center max-xl:px-[24px] max-md:px-[20px]">
         <Outlet />
       </main>
       <footer></footer>

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -6,7 +6,7 @@ const Layout = () => {
   return (
     <div>
       <header>헤더입니당</header>
-      <main className="flex xl:justify-center max-xl:px-[24px] max-md:px-[20px]">
+      <main className="flex justify-center max-xl:px-[24px] max-md:px-[20px]">
         <Outlet />
       </main>
       <footer></footer>

--- a/src/pages/RollingPaperList.jsx
+++ b/src/pages/RollingPaperList.jsx
@@ -1,9 +1,30 @@
 import React, { useEffect, useState } from 'react';
 import api from '../api/axios';
+import RollingPaperCarousel from '../components/RollingPaperCarousel';
 
 const RollingPaperList = () => {
   const [popularRollingPapers, setPopularRollingPapers] = useState([]);
   const [recentRollingPapers, setRecentRollingPapers] = useState([]);
+  const [popularIndex, setPopularIndex] = useState(0);
+  const [recentIndex, setRecentIndex] = useState(0);
+
+  const itemsPerView = 4; // 한 번에 보여질 카드 개수
+
+  const handlePopularNext = () => {
+    setPopularIndex((prev) => Math.min(prev + 1, popularRollingPapers.length - itemsPerView));
+  };
+
+  const handlePopularPrev = () => {
+    setPopularIndex((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handleRecentNext = () => {
+    setRecentIndex((prev) => Math.min(prev + 1, recentRollingPapers.length - itemsPerView));
+  };
+
+  const handleRecentPrev = () => {
+    setRecentIndex((prev) => Math.max(prev - 1, 0));
+  };
 
   useEffect(() => {
     const fetchRollingPaperList = async () => {
@@ -29,26 +50,22 @@ const RollingPaperList = () => {
 
   return (
     <div className="mt-[50px] flex flex-col gap-[50px]">
-      <div>
-        <div className="flex flex-col gap-[16px">
-          <span>인기 롤링 페이퍼 🔥</span>
-        </div>
-        <div>
-          {popularRollingPapers.map((paper) => (
-            <div key={paper.id}>{paper.name}</div>
-          ))}
-        </div>
-      </div>
-      <div>
-        <div className="flex flex-col gap-[16px]">
-          <span>최근에 만든 롤링 페이퍼 ⭐️️</span>
-        </div>
-        <div>
-          {recentRollingPapers.map((paper) => (
-            <div key={paper.id}>{paper.name}</div>
-          ))}
-        </div>
-      </div>
+      <RollingPaperCarousel
+        title="인기 롤링 페이퍼 🔥"
+        papers={popularRollingPapers}
+        currentIndex={popularIndex}
+        onNext={handlePopularNext}
+        onPrev={handlePopularPrev}
+        itemsPerView={itemsPerView}
+      />
+      <RollingPaperCarousel
+        title="최근에 만든 롤링 페이퍼 ⭐️️"
+        papers={recentRollingPapers}
+        currentIndex={recentIndex}
+        onNext={handleRecentNext}
+        onPrev={handleRecentPrev}
+        itemsPerView={itemsPerView}
+      />
     </div>
   );
 };

--- a/src/pages/RollingPaperList.jsx
+++ b/src/pages/RollingPaperList.jsx
@@ -8,7 +8,7 @@ const RollingPaperList = () => {
   const [popularIndex, setPopularIndex] = useState(0);
   const [recentIndex, setRecentIndex] = useState(0);
 
-  const itemsPerView = 4; // 한 번에 보여질 카드 개수
+  const itemsPerView = 4;
 
   const handlePopularNext = () => {
     setPopularIndex((prev) => Math.min(prev + 1, popularRollingPapers.length - itemsPerView));
@@ -32,11 +32,9 @@ const RollingPaperList = () => {
         const response = await api.getRecipients('13-2');
         const papers = response.data.results;
 
-        // 좋아요 수 기준으로 정렬하여 인기 롤링 페이퍼 설정
         const sortedByReactionCount = [...papers].sort((a, b) => b.reactionCount - a.reactionCount);
         setPopularRollingPapers(sortedByReactionCount);
 
-        // 생성일 기준으로 정렬하여 최근 롤링 페이퍼 설정
         const sortedByDate = [...papers].sort(
           (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
         );

--- a/src/pages/RollingPaperList.jsx
+++ b/src/pages/RollingPaperList.jsx
@@ -49,7 +49,7 @@ const RollingPaperList = () => {
   }, []);
 
   return (
-    <div className="mt-[50px] flex flex-col gap-[50px]">
+    <div className="mt-[50px] flex flex-col gap-[50px] overflow-hidden">
       <RollingPaperCarousel
         title="인기 롤링 페이퍼 🔥"
         papers={popularRollingPapers}


### PR DESCRIPTION
# 롤링 페이퍼 리스트 페이지 구현

## 작업 내용
- 롤링 페이퍼 리스트 페이지의 기본 레이아웃 구현
- 인기/최신 롤링 페이퍼 캐러셀 컴포넌트 구현
  - 반응형 디자인 적용 (모바일/데스크톱)
  - 좌우 네비게이션 버튼으로 슬라이드 기능 구현
  - 4개의 아이템을 한 번에 표시
- API 데이터 가공
  - 받아온 데이터를 클라이언트에서 인기순 정렬 (reactionCount 기준)
  - 받아온 데이터를 클라이언트에서 최신순 정렬 (createdAt 기준)

## 구현된 기능
- [x] 롤링 페이퍼 목록 API 연동
- [x] 캐러셀 슬라이드 기능
- [x] 반응형 UI (모바일/데스크톱)
- [x] 캐러셀 네비게이션 버튼 (이전/다음)
- [x] 캐러셀 아이템 개수에 따른 버튼 표시 로직
