### PR TITLE
refactor : 롤링페이퍼 정렬 로직 useMemo로 최적화

### DIFF
--- a/src/pages/RollingPaperList.jsx
+++ b/src/pages/RollingPaperList.jsx
@@ -1,14 +1,21 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import api from '../api/axios';
 import RollingPaperCarousel from '../components/RollingPaperCarousel';
 
 const RollingPaperList = () => {
-  const [popularRollingPapers, setPopularRollingPapers] = useState([]);
-  const [recentRollingPapers, setRecentRollingPapers] = useState([]);
+  const [rollingPapers, setRollingPapers] = useState([]);
   const [popularIndex, setPopularIndex] = useState(0);
   const [recentIndex, setRecentIndex] = useState(0);
 
   const itemsPerView = 4;
+
+  const popularRollingPapers = useMemo(() => {
+    return rollingPapers.toSorted((a, b) => b.reactionCount - a.reactionCount);
+  }, [rollingPapers]);
+
+  const recentRollingPapers = useMemo(() => {
+    return rollingPapers.toSorted((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }, [rollingPapers]);
 
   const handlePopularNext = () => {
     setPopularIndex((prev) => Math.min(prev + 1, popularRollingPapers.length - itemsPerView));
@@ -31,14 +38,7 @@ const RollingPaperList = () => {
       try {
         const response = await api.getRecipients('13-2');
         const papers = response.data.results;
-
-        const sortedByReactionCount = [...papers].sort((a, b) => b.reactionCount - a.reactionCount);
-        setPopularRollingPapers(sortedByReactionCount);
-
-        const sortedByDate = [...papers].sort(
-          (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
-        );
-        setRecentRollingPapers(sortedByDate);
+        setRollingPapers(papers);
       } catch (error) {
         console.error('Error fetching rolling paper list:', error);
       }


### PR DESCRIPTION
## 작업 내용
- 인기순/최신순 정렬 로직을 useMemo로 메모이제이션 처리
- rollingPapers 상태가 변경될 때만 재계산하도록 최적화

## 테스트
- 

## 스크린샷 (선택) 
- 

## 기타
- 
