### PR TITLE
refactor : Button 컴포넌트에 fullWidth prop 추가

### DIFF
--- a/src/components/common/button/index.jsx
+++ b/src/components/common/button/index.jsx
@@ -1,6 +1,14 @@
 import { baseStyles, variants, sizes } from './buttonStyle';
 
-const Button = ({ children, icon, variant, size, disabled = false, onClick }) => {
+const Button = ({
+  children,
+  icon,
+  variant,
+  size,
+  disabled = false,
+  onClick,
+  fullWidth = false,
+}) => {
   const buttonStyles = `${baseStyles} ${sizes[size]} ${variants[variant]}`;
 
   return (
@@ -8,7 +16,7 @@ const Button = ({ children, icon, variant, size, disabled = false, onClick }) =>
       className={`${buttonStyles} flex items-center justify-center gap-[4px]`}
       disabled={disabled}
       onClick={onClick}
-      style={{ width: '100%' }}
+      style={{ width: fullWidth ? '100%' : 'auto' }}
     >
       {icon && <img src={icon} alt="emoji icon" />}
       {children}


### PR DESCRIPTION
## 작업 내용
- Button 컴포넌트에 fullWidth prop 추가
- fullWidth 값이 true 일 때만 전체 너비를 갖게끔 설정

## 테스트
- 

## 스크린샷 (선택) 
-아무것도 건드리지 않은 상태 
![스크린샷 2025-02-06 134227](https://github.com/user-attachments/assets/bfd5a9d4-fbc1-4478-a258-09d4de2791a1)
-fullWidth={true}값을 주면
![스크린샷 2025-02-06 134255](https://github.com/user-attachments/assets/6bf07fee-5ff8-41c4-82b0-9f149c6cea40)
-너비가 100%를 차지하려고 함
![스크린샷 2025-02-06 134304](https://github.com/user-attachments/assets/f8393912-3cf6-4005-8e39-1163260d5c5c)


## 기타
- 
