### PR TITLE
Feature/message

### DIFF
--- a/src/pages/message/index.jsx
+++ b/src/pages/message/index.jsx
@@ -1,17 +1,15 @@
 import InputWithError from './components/InputWithError';
 import ProfileImg from './components/ProfileImg';
-import api from '../../api/axios';
 import profilePreview from '../../assets/images/profile.svg';
 import Select from './components/Select';
 import Editor from './components/Editor';
 import Button from '../../components/common/button/index';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import useProfileImages from './utils/useProfileImages';
 
 const Message = () => {
   const [sender, setSender] = useState('');
   const [isValid, setIsValid] = useState(true);
-  const [images, setImages] = useState([]);
-  const [loadingError, setLoadingError] = useState(false);
   const [profileImg, setProfileImg] = useState(profilePreview);
   const [selectedRelation, setSelectedRelation] = useState('지인');
   const [editorContent, setEditorContent] = useState('');
@@ -20,24 +18,11 @@ const Message = () => {
   const fontOptions = ['Noto Sans', 'Pretendard', '나눔명조', '나눔손글씨 손편지체'];
 
   const handleInputChange = (e) => {
-    setSender(e.target.value); // 공백 제거 후 상태 업데이트
+    setSender(e.target.value.trim()); // 공백 제거 후 상태 업데이트
     setIsValid(true);
   };
 
-  // 예시 프로필 이미지 요청
-  useEffect(() => {
-    const getProfileImages = async () => {
-      try {
-        const response = await api.getProfileImages();
-        setImages(response.data.imageUrls);
-        setLoadingError(false);
-      } catch (e) {
-        setLoadingError(true);
-        console.error(e);
-      }
-    };
-    getProfileImages();
-  }, []);
+  const { images, loadingError } = useProfileImages();
 
   return (
     <form className="container max-w-[720px] mx-auto mt-[47px] flex flex-col ">

--- a/src/pages/message/index.jsx
+++ b/src/pages/message/index.jsx
@@ -4,7 +4,7 @@ import profilePreview from '../../assets/images/profile.svg';
 import Select from './components/Select';
 import Editor from './components/Editor';
 import Button from '../../components/common/button/index';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useProfileImages from './utils/useProfileImages';
 
 const Message = () => {
@@ -16,6 +16,7 @@ const Message = () => {
   const [selectedFont, setSelectedFont] = useState('Noto Sans');
   const relationOptions = ['친구', '지인', '동료', '가족'];
   const fontOptions = ['Noto Sans', 'Pretendard', '나눔명조', '나눔손글씨 손편지체'];
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const handleInputChange = (e) => {
     setSender(e.target.value.trim()); // 공백 제거 후 상태 업데이트
@@ -23,6 +24,12 @@ const Message = () => {
   };
 
   const { images, loadingError } = useProfileImages();
+
+  useEffect(() => {
+    if (sender.trim() !== '' && editorContent.trim() !== '') {
+      setIsFormValid(true);
+    }
+  }, [sender, editorContent]);
 
   return (
     <form className="container max-w-[720px] mx-auto mt-[47px] flex flex-col ">
@@ -72,7 +79,8 @@ const Message = () => {
           variant="primary"
           size="lg"
           type="submit"
-          disabled={!(sender !== '' && editorContent !== '')}
+          fullWidth="true"
+          disabled={!isFormValid}
           children="생성하기"
         ></Button>
       </div>

--- a/src/pages/message/utils/useProfileImages.jsx
+++ b/src/pages/message/utils/useProfileImages.jsx
@@ -1,0 +1,26 @@
+import api from '../../../api/axios';
+import { useState, useEffect } from 'react';
+
+export const useProfileImages = () => {
+  const [images, setImages] = useState([]);
+  const [loadingError, setLoadingError] = useState(false);
+
+  // 예시 프로필 이미지 요청
+  useEffect(() => {
+    const getProfileImages = async () => {
+      try {
+        const response = await api.getProfileImages();
+        setImages(response.data.imageUrls);
+        setLoadingError(false);
+      } catch (e) {
+        setLoadingError(true);
+        console.error(e);
+      }
+    };
+    getProfileImages();
+  }, []);
+
+  return { images, loadingError };
+};
+
+export default useProfileImages;


### PR DESCRIPTION
## 작업 내용
- 보내는 사람, 에디터 내용 입력에 따라 버튼 활성화가 지연되는 문제 해결
- 입력값의 `trim( )` 처리로 유저가 공백을 입력하는 예외 상황에 대응
- 예시 프로필 이미지 API 요청을 커스텀 훅으로 분리

## 테스트
- 보내는 사람, 에디터 내용을 입력하면 버튼이 지연 없이 활성화됨

## 스크린샷 (선택) 

https://github.com/user-attachments/assets/ef287e11-1cf5-4c0b-abe0-ac526efc3d55


## 기타
