### PR TITLE
feat : API 엔드 포인트에 페이지네이션 파라미터 offset,limit 추가

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -7,6 +7,15 @@ export const apiClient = axios.create({
   },
 });
 
+const buildOffsetLimitQuery = (offset, limit) => {
+  const params = new URLSearchParams();
+
+  if (offset !== undefined) params.append('offset', offset);
+  if (limit !== undefined) params.append('limit', limit);
+  
+  return params.toString() ? `?${params.toString()}` : '';
+};
+
 const apiRoutes = {
   // Background Images
   backgroundImages: '/background-images/',
@@ -19,10 +28,14 @@ const apiRoutes = {
 
   // Recipients
   recipients: {
-    base: (team, recipientId) =>
-      recipientId ? `/${team}/recipients/${recipientId}/` : `/${team}/recipients/`,
-    messages: (team, recipientId) => `/${team}/recipients/${recipientId}/messages/`,
-    reactions: (team, recipientId) => `/${team}/recipients/${recipientId}/reactions/`,
+    list: (team, offset, limit) => 
+      `/${team}/recipients/${buildOffsetLimitQuery(offset, limit)}`,
+    detail: (team, recipientId) => 
+      `/${team}/recipients/${recipientId}/`,
+    messages: (team, recipientId, offset, limit) =>
+      `/${team}/recipients/${recipientId}/messages/${buildOffsetLimitQuery(offset, limit)}`,
+    reactions: (team, recipientId, offset, limit) =>
+      `/${team}/recipients/${recipientId}/reactions/${buildOffsetLimitQuery(offset, limit)}`,
   },
 };
 
@@ -41,21 +54,21 @@ const api = {
   deleteMessages: (team, messageId) => apiClient.delete(apiRoutes.messages(team, messageId)),
 
   // Recipients
-  getRecipients: (team) => apiClient.get(apiRoutes.recipients.base(team)),
-  postRecipients: (team, data) => apiClient.post(apiRoutes.recipients.base(team), data),
-  getRecipients: (team, recipientId) => apiClient.get(apiRoutes.recipients.base(team, recipientId)),
+  getRecipientsList: (team, offset, limit) => apiClient.get(apiRoutes.recipients.list(team, offset, limit)),
+  getRecipientById: (team, recipientId) => apiClient.get(apiRoutes.recipients.detail(team, recipientId)),
+  postRecipients: (team, data) => apiClient.post(apiRoutes.recipients.detail(team), data),
   deleteRecipients: (team, recipientId) =>
-    apiClient.delete(apiRoutes.recipients.base(team, recipientId)),
+    apiClient.delete(apiRoutes.recipients.detail(team, recipientId)),
 
   // Recipient Messages
-  getRecipientsMessages: (team, recipientId) =>
-    apiClient.get(apiRoutes.recipients.messages(team, recipientId)),
+  getRecipientsMessages: (team, recipientId, offset, limit) =>
+    apiClient.get(apiRoutes.recipients.messages(team, recipientId, offset, limit)),
   postRecipientsMessages: (team, recipientId, data) =>
     apiClient.post(apiRoutes.recipients.messages(team, recipientId), data),
 
   // Recipient Reactions
-  getRecipientsReactions: (team, recipientId) =>
-    apiClient.get(apiRoutes.recipients.reactions(team, recipientId)),
+  getRecipientsReactions: (team, recipientId, offset, limit) =>
+    apiClient.get(apiRoutes.recipients.reactions(team, recipientId, offset, limit)),
   postRecipientsReactions: (team, recipientId, data) =>
     apiClient.post(apiRoutes.recipients.reactions(team, recipientId), data),
 };

--- a/src/pages/list/index.jsx
+++ b/src/pages/list/index.jsx
@@ -36,7 +36,7 @@ const RollingPaperList = () => {
   useEffect(() => {
     const fetchRollingPaperList = async () => {
       try {
-        const response = await api.getRecipients('13-2');
+        const response = await api.getRecipientsList('13-2');
         const papers = response.data.results;
         setRollingPapers(papers);
       } catch (error) {


### PR DESCRIPTION
## 작업 내용
1.  페이지네이션 쿼리 생성을 위한 유틸리티 함수 추가
  - offset과 limit 값을 받아서 데이터베이스 쿼리에 적용할 수 있는 형태로 변환
2.  API 라우트에 페이지네이션 파라미터 적용
  - 클라이언트가 요청 시 offset과 limit 값을 쿼리 파라미터로 전달 가능

## 테스트
- 

## 스크린샷 (선택) 
- 

## 기타
- 
