### PR TITLE
refactor : 캐러셀 버튼 스타일 및 변수명 개선

### DIFF
--- a/src/pages/list/components/CarouselButton.jsx
+++ b/src/pages/list/components/CarouselButton.jsx
@@ -2,11 +2,11 @@ import prevButton from '../../../assets/images/arrow_left.svg';
 import nextButton from '../../../assets/images/arrow_right.svg';
 
 const BUTTON_STYLES = {
-  prev: 'left-0 translate-x-[-50%]',
-  next: 'right-0 translate-x-[50%]',
+  prev: 'left-0 -translate-x-1/2',
+  next: 'right-0 translate-x-1/2',
 };
 
-const BUTTON_PROPS = {
+const BUTTON_ATTRIBUTES = {
   prev: {
     src: prevButton,
     alt: '이전 버튼',
@@ -33,7 +33,7 @@ const CarouselButton = ({ direction = 'next', onClick, className, position = 'to
 
   return (
     <button className={`${baseStyles} ${className}`} onClick={onClick}>
-      <img src={BUTTON_PROPS[direction].src} alt={BUTTON_PROPS[direction].alt} />
+      <img {...BUTTON_ATTRIBUTES[direction]} />
     </button>
   );
 };


### PR DESCRIPTION
## 작업 내용
- BUTTON_PROPS를 BUTTON_ATTRIBUTES로 이름 변경하여 의미 명확화
- 캐러셀 버튼 위치 스타일을 Tailwind 클래스 문법으로 통일
  - translate-x-[-50%] → -translate-x-1/2
  - translate-x-[50%] → translate-x-1/2

## 테스트
- 

## 스크린샷 (선택) 
- 

## 기타
- 
